### PR TITLE
Rename methods to say FQDN instead of IP

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -138,12 +138,12 @@ module DeliveryCluster
       end
     end
 
-    def chef_server_ip
-      @chef_server_ip ||= begin
+    def chef_server_fqdn
+      @chef_server_fqdn ||= begin
         chef_server_node = Chef::Node.load(chef_server_hostname)
-        chef_server_ip   = get_ip(chef_server_node)
-        Chef::Log.info("Your Chef Server Public/Private IP is => #{chef_server_ip}")
-        node['delivery-cluster']['chef-server']['fqdn'] || chef_server_ip
+        chef_server_fqdn   = get_ip(chef_server_node)
+        Chef::Log.info("Your Chef Server Public/Private IP is => #{chef_server_fqdn}")
+        node['delivery-cluster']['chef-server']['fqdn'] || chef_server_fqdn
       end
     end
 
@@ -179,19 +179,19 @@ module DeliveryCluster
       end
     end
 
-    def analytics_server_ip
-      @analytics_server_ip ||= begin
-        analytics_server_ip   = get_ip(analytics_server_node)
-        Chef::Log.info("Your Analytics Server Public/Private IP is => #{analytics_server_ip}")
-        node['delivery-cluster']['analytics']['fqdn'] || analytics_server_ip
+    def analytics_server_fqdn
+      @analytics_server_fqdn ||= begin
+        analytics_server_fqdn   = get_ip(analytics_server_node)
+        Chef::Log.info("Your Analytics Server Public/Private IP is => #{analytics_server_fqdn}")
+        node['delivery-cluster']['analytics']['fqdn'] || analytics_server_fqdn
       end
     end
 
-    def supermarket_server_ip
-      @supermarket_server_ip ||= begin
-        supermarket_server_ip   = get_ip(supermarket_server_node)
-        Chef::Log.info("Your Supermarket Server Public/Private IP is => #{supermarket_server_ip}")
-        node['delivery-cluster']['supermarket']['fqdn'] || supermarket_server_ip
+    def supermarket_server_fqdn
+      @supermarket_server_fqdn ||= begin
+        supermarket_server_fqdn   = get_ip(supermarket_server_node)
+        Chef::Log.info("Your Supermarket Server Public/Private IP is => #{supermarket_server_fqdn}")
+        node['delivery-cluster']['supermarket']['fqdn'] || supermarket_server_fqdn
       end
     end
 
@@ -204,7 +204,7 @@ module DeliveryCluster
     end
 
     def chef_server_url
-      "https://#{chef_server_ip}/organizations/#{node['delivery-cluster']['chef-server']['organization']}"
+      "https://#{chef_server_fqdn}/organizations/#{node['delivery-cluster']['chef-server']['organization']}"
     end
 
     def activate_splunk
@@ -236,7 +236,7 @@ module DeliveryCluster
       {
         'chef-server-12' => {
           'analytics' => {
-            'fqdn' => analytics_server_ip
+            'fqdn' => analytics_server_fqdn
           }
         }
       }
@@ -247,7 +247,7 @@ module DeliveryCluster
       {
         'chef-server-12' => {
           'supermarket' => {
-            'fqdn' => supermarket_server_ip
+            'fqdn' => supermarket_server_fqdn
           }
         }
       }
@@ -257,7 +257,7 @@ module DeliveryCluster
       @chef_server_attributes = {
         'chef-server-12' => {
           'delivery' => { 'organization' => node['delivery-cluster']['chef-server']['organization'] },
-          'api_fqdn' => chef_server_ip,
+          'api_fqdn' => chef_server_fqdn,
           'store_keys_databag' => false,
           'plugin' => {
             'opscode-reporting' => false
@@ -289,11 +289,11 @@ module DeliveryCluster
       end
     end
 
-    def delivery_server_ip
-      @delivery_server_ip ||= begin
-        delivery_server_ip   = get_ip(delivery_server_node)
-        Chef::Log.info("Your Delivery Server Public/Private IP is => #{delivery_server_ip}")
-        node['delivery-cluster']['delivery']['fqdn'] || delivery_server_ip
+    def delivery_server_fqdn
+      @delivery_server_fqdn ||= begin
+        delivery_server_fqdn   = get_ip(delivery_server_node)
+        Chef::Log.info("Your Delivery Server Public/Private IP is => #{delivery_server_fqdn}")
+        node['delivery-cluster']['delivery']['fqdn'] || delivery_server_fqdn
       end
     end
 
@@ -310,7 +310,7 @@ module DeliveryCluster
       node.set['delivery-cluster']['delivery']['chef_server'] = chef_server_url unless node['delivery-cluster']['delivery']['chef_server']
 
       # Ensure we havea Delivery FQDN
-      node.set['delivery-cluster']['delivery']['fqdn'] = delivery_server_ip unless node['delivery-cluster']['delivery']['fqdn']
+      node.set['delivery-cluster']['delivery']['fqdn'] = delivery_server_fqdn unless node['delivery-cluster']['delivery']['fqdn']
 
       { 'delivery-cluster' => node['delivery-cluster'] }
     end
@@ -396,12 +396,12 @@ module DeliveryCluster
             chef_server_url:      chef_server_url,
             client_key:           "#{cluster_data_dir}/delivery.pem",
             analytics_server_url: if analytics_enabled?
-                                    "https://#{analytics_server_ip}/organizations" \
+                                    "https://#{analytics_server_fqdn}/organizations" \
                                     "/#{node['delivery-cluster']['chef-server']['organization']}"
                                   else
                                     ''
                                   end,
-            supermarket_site:     supermarket_enabled? ? "https://#{supermarket_server_ip}" : ''
+            supermarket_site:     supermarket_enabled? ? "https://#{supermarket_server_fqdn}" : ''
           }
         }
       end

--- a/recipes/setup_analytics.rb
+++ b/recipes/setup_analytics.rb
@@ -37,7 +37,7 @@ machine analytics_server_hostname do
   end
   files lazy {
     {
-      "/etc/chef/trusted_certs/#{chef_server_ip}.crt" => "#{Chef::Config[:trusted_certs_dir]}/#{chef_server_ip}.crt"
+      "/etc/chef/trusted_certs/#{chef_server_fqdn}.crt" => "#{Chef::Config[:trusted_certs_dir]}/#{chef_server_fqdn}.crt"
     }
   }
   action :converge
@@ -74,7 +74,7 @@ machine analytics_server_hostname do
     {
       'delivery-cluster' => {
         'analytics' => {
-          'fqdn' => analytics_server_ip,
+          'fqdn' => analytics_server_fqdn,
           'features' => splunk_enabled? ? 'true' : 'false'
         }
       }
@@ -86,9 +86,9 @@ end
 
 machine_file 'analytics-server-cert' do
   chef_server lazy { chef_server_config }
-  path lazy { "/var/opt/opscode-analytics/ssl/ca/#{analytics_server_ip}.crt" }
+  path lazy { "/var/opt/opscode-analytics/ssl/ca/#{analytics_server_fqdn}.crt" }
   machine analytics_server_hostname
-  local_path lazy { "#{Chef::Config[:trusted_certs_dir]}/#{analytics_server_ip}.crt" }
+  local_path lazy { "#{Chef::Config[:trusted_certs_dir]}/#{analytics_server_fqdn}.crt" }
   action :download
 end
 

--- a/recipes/setup_chef_server.rb
+++ b/recipes/setup_chef_server.rb
@@ -57,9 +57,9 @@ directory Chef::Config[:trusted_certs_dir] do
 end
 
 machine_file 'chef-server-cert' do
-  path lazy { "/var/opt/opscode/nginx/ca/#{chef_server_ip}.crt" }
+  path lazy { "/var/opt/opscode/nginx/ca/#{chef_server_fqdn}.crt" }
   machine chef_server_hostname
-  local_path lazy { "#{Chef::Config[:trusted_certs_dir]}/#{chef_server_ip}.crt" }
+  local_path lazy { "#{Chef::Config[:trusted_certs_dir]}/#{chef_server_fqdn}.crt" }
   action :download
 end
 

--- a/recipes/setup_delivery.rb
+++ b/recipes/setup_delivery.rb
@@ -68,7 +68,7 @@ machine delivery_server_hostname do
   end
   files lazy {
     {
-      "/etc/chef/trusted_certs/#{chef_server_ip}.crt" => "#{Chef::Config[:trusted_certs_dir]}/#{chef_server_ip}.crt"
+      "/etc/chef/trusted_certs/#{chef_server_fqdn}.crt" => "#{Chef::Config[:trusted_certs_dir]}/#{chef_server_fqdn}.crt"
     }
   }
   action :converge
@@ -121,9 +121,9 @@ end
 
 machine_file 'delivery-server-cert' do
   chef_server lazy { chef_server_config }
-  path lazy { "/var/opt/delivery/nginx/ca/#{delivery_server_ip}.crt" }
+  path lazy { "/var/opt/delivery/nginx/ca/#{delivery_server_fqdn}.crt" }
   machine delivery_server_hostname
-  local_path lazy { "#{Chef::Config[:trusted_certs_dir]}/#{delivery_server_ip}.crt" }
+  local_path lazy { "#{Chef::Config[:trusted_certs_dir]}/#{delivery_server_fqdn}.crt" }
   action :download
 end
 
@@ -170,8 +170,8 @@ machine_batch "#{node['delivery-cluster']['builders']['count']}-build-nodes" do
       end
       files lazy {
         {
-          "/etc/chef/trusted_certs/#{chef_server_ip}.crt" => "#{Chef::Config[:trusted_certs_dir]}/#{chef_server_ip}.crt",
-          "/etc/chef/trusted_certs/#{delivery_server_ip}.crt" => "#{Chef::Config[:trusted_certs_dir]}/#{delivery_server_ip}.crt",
+          "/etc/chef/trusted_certs/#{chef_server_fqdn}.crt" => "#{Chef::Config[:trusted_certs_dir]}/#{chef_server_fqdn}.crt",
+          "/etc/chef/trusted_certs/#{delivery_server_fqdn}.crt" => "#{Chef::Config[:trusted_certs_dir]}/#{delivery_server_fqdn}.crt",
           '/etc/chef/encrypted_data_bag_secret' => "#{cluster_data_dir}/encrypted_data_bag_secret"
         }
       }

--- a/recipes/setup_splunk.rb
+++ b/recipes/setup_splunk.rb
@@ -86,7 +86,7 @@ machine splunk_server_hostname do
   end
   files lazy {
     {
-      "/etc/chef/trusted_certs/#{chef_server_ip}.crt" => "#{Chef::Config[:trusted_certs_dir]}/#{chef_server_ip}.crt"
+      "/etc/chef/trusted_certs/#{chef_server_fqdn}.crt" => "#{Chef::Config[:trusted_certs_dir]}/#{chef_server_fqdn}.crt"
     }
   }
   action :converge

--- a/recipes/setup_supermarket.rb
+++ b/recipes/setup_supermarket.rb
@@ -37,7 +37,7 @@ machine supermarket_server_hostname do
   end
   files lazy {
     {
-      "/etc/chef/trusted_certs/#{chef_server_ip}.crt" => "#{Chef::Config[:trusted_certs_dir]}/#{chef_server_ip}.crt"
+      "/etc/chef/trusted_certs/#{chef_server_fqdn}.crt" => "#{Chef::Config[:trusted_certs_dir]}/#{chef_server_fqdn}.crt"
     }
   }
   action :converge
@@ -67,7 +67,7 @@ machine supermarket_server_hostname do
   attributes lazy {
     {
       'supermarket_omnibus' => {
-        'chef_server_url' => "https://#{chef_server_ip}",
+        'chef_server_url' => "https://#{chef_server_fqdn}",
         'chef_oauth2_app_id' => get_supermarket_attribute('uid'),
         'chef_oauth2_secret' => get_supermarket_attribute('secret'),
         'chef_oauth2_verify_ssl' => false
@@ -80,9 +80,9 @@ end
 
 machine_file 'supermarket-server-cert' do
   chef_server lazy { chef_server_config }
-  path lazy { "/var/opt/supermarket/ssl/ca/#{supermarket_server_ip}.crt" }
+  path lazy { "/var/opt/supermarket/ssl/ca/#{supermarket_server_fqdn}.crt" }
   machine supermarket_server_hostname
-  local_path lazy { "#{Chef::Config[:trusted_certs_dir]}/#{supermarket_server_ip}.crt" }
+  local_path lazy { "#{Chef::Config[:trusted_certs_dir]}/#{supermarket_server_fqdn}.crt" }
   action :download
 end
 


### PR DESCRIPTION
Lets honor the methods names with the actual thing they are doing.

It is very confusing that the methods says `chef_server_ip` when in
reality it is getting the `fqdn` and if that doesn't exist then we
get the ip address.

This change also prepares another change to fix:
https://github.com/opscode-cookbooks/delivery-cluster/issues/94