### PR TITLE
Honor `host` instead of `ip`

### DIFF
--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -141,9 +141,11 @@ module DeliveryCluster
     def chef_server_fqdn
       @chef_server_fqdn ||= begin
         chef_server_node = Chef::Node.load(chef_server_hostname)
-        chef_server_fqdn   = get_ip(chef_server_node)
+        chef_server_fqdn = get_ip(chef_server_node)
         Chef::Log.info("Your Chef Server Public/Private IP is => #{chef_server_fqdn}")
-        node['delivery-cluster']['chef-server']['fqdn'] || chef_server_fqdn
+        node['delivery-cluster']['chef-server']['fqdn'] ||
+        node['delivery-cluster']['chef-server']['host'] ||
+        chef_server_fqdn
       end
     end
 
@@ -181,17 +183,21 @@ module DeliveryCluster
 
     def analytics_server_fqdn
       @analytics_server_fqdn ||= begin
-        analytics_server_fqdn   = get_ip(analytics_server_node)
+        analytics_server_fqdn  = get_ip(analytics_server_node)
         Chef::Log.info("Your Analytics Server Public/Private IP is => #{analytics_server_fqdn}")
-        node['delivery-cluster']['analytics']['fqdn'] || analytics_server_fqdn
+        node['delivery-cluster']['analytics']['fqdn'] ||
+        node['delivery-cluster']['analytics']['host'] ||
+        analytics_server_fqdn
       end
     end
 
     def supermarket_server_fqdn
       @supermarket_server_fqdn ||= begin
-        supermarket_server_fqdn   = get_ip(supermarket_server_node)
+        supermarket_server_fqdn  = get_ip(supermarket_server_node)
         Chef::Log.info("Your Supermarket Server Public/Private IP is => #{supermarket_server_fqdn}")
-        node['delivery-cluster']['supermarket']['fqdn'] || supermarket_server_fqdn
+        node['delivery-cluster']['supermarket']['fqdn'] ||
+        node['delivery-cluster']['supermarket']['host'] ||
+        supermarket_server_fqdn
       end
     end
 
@@ -291,9 +297,11 @@ module DeliveryCluster
 
     def delivery_server_fqdn
       @delivery_server_fqdn ||= begin
-        delivery_server_fqdn   = get_ip(delivery_server_node)
+        delivery_server_fqdn  = get_ip(delivery_server_node)
         Chef::Log.info("Your Delivery Server Public/Private IP is => #{delivery_server_fqdn}")
-        node['delivery-cluster']['delivery']['fqdn'] || delivery_server_fqdn
+        node['delivery-cluster']['delivery']['fqdn'] ||
+        node['delivery-cluster']['delivery']['host'] ||
+        delivery_server_fqdn
       end
     end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'Apache 2.0'
 description      'Deployment cookbook for standing up Delivery Clusters'
 long_description 'Installs Chef Delivery, a solution for continuously ' \
                  'delivering applications and infrastructure safely at speed'
-version          '0.2.9'
+version          '0.2.10'
 
 depends 'chef-server-12'
 depends 'chef-server-ingredient'


### PR DESCRIPTION
When customers specify the `host` attribute they are expecting to use it
instead of the `fqdn`.

This commit will honor the following sequence:

* Use FQDN
* If not, use HOST
* If not, use IP Address

This commit fixes https://github.com/opscode-cookbooks/delivery-cluster/issues/94