### PR TITLE
update berkshelf to 3.2.4 to fix 'berks vendor cookbooks' failure 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'artifactory',           '~> 2.2'
-gem 'berkshelf',             '~> 3.2'
+gem 'berkshelf',             '~> 3.2.4'
 gem 'chef',                  '~> 12.0'
 gem 'chef-vault'
 gem 'chef-provisioning',     git: 'https://github.com/chef/chef-provisioning.git',

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
     aws-sdk-v1 (1.64.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    berkshelf (3.2.3)
+    berkshelf (3.2.4)
       addressable (~> 2.3.4)
       berkshelf-api-client (~> 1.2)
       buff-config (~> 1.0)
@@ -274,7 +274,7 @@ PLATFORMS
 
 DEPENDENCIES
   artifactory (~> 2.2)
-  berkshelf (~> 3.2)
+  berkshelf (~> 3.2.4)
   chef (~> 12.0)
   chef-provisioning!
   chef-provisioning-aws!

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'Apache 2.0'
 description      'Deployment cookbook for standing up Delivery Clusters'
 long_description 'Installs Chef Delivery, a solution for continuously ' \
                  'delivering applications and infrastructure safely at speed'
-version          '0.2.16'
+version          '0.2.17'
 
 depends 'chef-server-12'
 depends 'chef-server-ingredient'


### PR DESCRIPTION
Bug fix in Berkshelf https://github.com/berkshelf/berkshelf/pull/1342 was causing 'berks vendor cookbooks' to fail.

Update berkshelf to 3.2.4 to fix issue.