### PR TITLE
Use node.hostname instead of node.name, we don't want to redefine the hostname

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -21,7 +21,7 @@ DEPENDENCIES
 
 GRAPH
   build-essential (2.2.3)
-  chef-server-12 (0.1.5)
+  chef-server-12 (0.1.7)
     chef-server-ingredient (>= 0.0.0)
     hostsfile (>= 0.0.0)
   chef-server-ingredient (0.3.2)
@@ -30,7 +30,7 @@ GRAPH
     chef-vault (>= 1.0.4)
   chef-vault (1.3.0)
   chef_handler (1.1.6)
-  delivery-cluster (0.2.17)
+  delivery-cluster (0.2.19)
     chef-server-12 (>= 0.0.0)
     chef-server-ingredient (>= 0.0.0)
     chef-splunk (>= 0.0.0)

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'Apache 2.0'
 description      'Deployment cookbook for standing up Delivery Clusters'
 long_description 'Installs Chef Delivery, a solution for continuously ' \
                  'delivering applications and infrastructure safely at speed'
-version          '0.2.18'
+version          '0.2.19'
 
 depends 'chef-server-12'
 depends 'chef-server-ingredient'

--- a/vendor/chef-server-12/metadata.rb
+++ b/vendor/chef-server-12/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'afiune@chef.io'
 license          'Apache 2.0'
 description      'Installs/Configures chef-server-12'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.6'
+version          '0.1.7'
 
 depends 'chef-server-ingredient'
 depends 'hostsfile'

--- a/vendor/chef-server-12/recipes/default.rb
+++ b/vendor/chef-server-12/recipes/default.rb
@@ -22,8 +22,8 @@
 
 # Configure chef server hostname in /etc/hosts if it isn't there
 hostsfile_entry node['ipaddress'] do
-  hostname node.name
-  not_if "grep #{node.name} /etc/hosts"
+  hostname node.hostname
+  not_if "grep #{node.hostname} /etc/hosts"
 end
 
 directory "/etc/opscode" do


### PR DESCRIPTION
My bad, my last PR ( #121 ) redefined the hostname of the chef-server in /etc/hosts from the native AWS hostname (ex: `ip-33-33-33-35`) to the delivery-cluster assigned hostname (ex: `chef-server-irving-aws` )

This PR uses the originally assigned hostname, and should repair anyone who used the previous commit.