### PR TITLE
Install stable delivery packages instead of bleeding edge

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -105,6 +105,9 @@ default['delivery-cluster']['delivery']['ldap']        = {}
 # 1) If you want to deploy the latest Delivery Build set the version to
 #    'latest' and we will pull it down from `packagecloud`
 # => default['delivery-cluster']['delivery']['version'] = 'latest'
+#    Note that will pull from stable packages; if you want to pull from
+#    bleeding edge, untested packages (not recommended!), please use
+# => default['delivery-cluster']['delivery']['packagecloud-channel'] = 'current'
 #
 # 2) If you want to deploy a specific version you can also specify it
 #    To see the available versions go to:
@@ -114,10 +117,11 @@ default['delivery-cluster']['delivery']['ldap']        = {}
 # 3) You can also specify the artifact
 #
 # => default['delivery-cluster']['delivery']['version']   = '0.3.7'
-# => default['delivery-cluster']['delivery']['artifact']  = 'http://my.delivery-cli.pkg'
+# => default['delivery-cluster']['delivery']['artifact']  = 'http://my.delivery.pkg'
 # => default['delivery-cluster']['delivery']['checksum']  = '123456789ABCDEF'
 #
 default['delivery-cluster']['delivery']['version'] = 'latest'
+default['delivery-cluster']['delivery']['packagecloud-channel'] = 'stable'
 
 # Use Chef Artifactory (Requires Chef VPN)
 default['delivery-cluster']['delivery']['artifactory'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'Apache 2.0'
 description      'Deployment cookbook for standing up Delivery Clusters'
 long_description 'Installs Chef Delivery, a solution for continuously ' \
                  'delivering applications and infrastructure safely at speed'
-version          '0.2.18'
+version          '0.2.19'
 
 depends 'chef-server-12'
 depends 'chef-server-ingredient'

--- a/recipes/delivery.rb
+++ b/recipes/delivery.rb
@@ -52,7 +52,7 @@ if node['delivery-cluster']['delivery']['artifact']
   end
 else
   # Lets Install from packagecloud
-  packagecloud_repo 'chef/current' do
+  packagecloud_repo "chef/#{node['delivery-cluster']['delivery']['packagecloud-channel']}" do
     type value_for_platform_family(debian: 'deb', rhel: 'rpm')
   end
 


### PR DESCRIPTION
Still possible to install packages from the 'current' channel by setting
the `['delivery-cluster']['delivery']['ckagecloud-channel']` node attribute
to `'current'`