### PR TITLE
Move the reporting enable/disable into an attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -130,6 +130,13 @@ default['delivery-cluster']['chef-server']['flavor']       = 't2.medium'
 default['delivery-cluster']['chef-server']['existing']     = false
 default['delivery-cluster']['chef-server']['recipes']      = []
 
+# Disable the opscode-reporting module by default
+# Context: There is a bug at present where reporting may fail to install
+# due to a port conflict with the chef-zero process that's configuring it.
+# Moving out of an explicit disable in _helper.rb and into an atribute
+# Reference: libraries/_helper.rb, line 241
+default['delivery-cluster']['chef-server']['enable-reporting'] = false
+
 # => Analytics Server (Not Required)
 #
 # In order to provision an Analytics Server you have to first provision the entire

--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -238,7 +238,7 @@ module DeliveryCluster
           'api_fqdn' => chef_server_fqdn,
           'store_keys_databag' => false,
           'plugin' => {
-            'opscode-reporting' => false
+            'opscode-reporting' => node['delivery-cluster']['chef-server']['enable-reporting']
           }
         }
       }


### PR DESCRIPTION
opscode-reporting is currently explicitly disabled in libraries/_helper.rb. Moving that into an attribute so that it can be overridden if need be.