### PR TITLE
Rycar/provisioning update

### DIFF
--- a/libraries/aws.rb
+++ b/libraries/aws.rb
@@ -93,8 +93,8 @@ module DeliveryCluster
         return [] unless @node['delivery-cluster'][component]
         options = []
         options << { bootstrap_options: { instance_type: @node['delivery-cluster'][component]['flavor'] } } if @node['delivery-cluster'][component]['flavor']
-        options << { bootstrap_options: { instance_type: @node['delivery-cluster'][component]['security_group_ids'] } } if @node['delivery-cluster'][component]['security_group_ids']
-        options << { bootstrap_options: { instance_type: @node['delivery-cluster'][component]['image_id'] } } if @node['delivery-cluster'][component]['image_id']
+        options << { bootstrap_options: { security_group_ids: @node['delivery-cluster'][component]['security_group_ids'] } } if @node['delivery-cluster'][component]['security_group_ids']
+        options << { image_id: @node['delivery-cluster'][component]['image_id'] } if @node['delivery-cluster'][component]['image_id']
         # Specify more specific machine_options to add
       end
 

--- a/libraries/aws.rb
+++ b/libraries/aws.rb
@@ -93,6 +93,8 @@ module DeliveryCluster
         return [] unless @node['delivery-cluster'][component]
         options = []
         options << { bootstrap_options: { instance_type: @node['delivery-cluster'][component]['flavor'] } } if @node['delivery-cluster'][component]['flavor']
+        options << { bootstrap_options: { instance_type: @node['delivery-cluster'][component]['security_group_ids'] } } if @node['delivery-cluster'][component]['security_group_ids']
+        options << { bootstrap_options: { instance_type: @node['delivery-cluster'][component]['image_id'] } } if @node['delivery-cluster'][component]['image_id']
         # Specify more specific machine_options to add
       end
 

--- a/libraries/aws.rb
+++ b/libraries/aws.rb
@@ -96,6 +96,7 @@ module DeliveryCluster
         options << { bootstrap_options: { security_group_ids: @node['delivery-cluster'][component]['security_group_ids'] } } if @node['delivery-cluster'][component]['security_group_ids']
         options << { image_id: @node['delivery-cluster'][component]['image_id'] } if @node['delivery-cluster'][component]['image_id']
         # Specify more specific machine_options to add
+        options
       end
 
       # Return the Provisioning Driver Name.

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'Apache 2.0'
 description      'Deployment cookbook for standing up Delivery Clusters'
 long_description 'Installs Chef Delivery, a solution for continuously ' \
                  'delivering applications and infrastructure safely at speed'
-version          '0.2.19'
+version          '0.2.20'
 
 depends 'chef-server-12'
 depends 'chef-server-ingredient'


### PR DESCRIPTION
Now allows you to set AMI and Security Groups on a per-component basis. If a component doesn't have a custom AMI/SG defined, it will default to the shared aws settings.