### PR TITLE
Run delivery-ctl reconfigure after a delivery upgrade

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -30,7 +30,7 @@ GRAPH
     chef-vault (>= 1.0.4)
   chef-vault (1.3.0)
   chef_handler (1.1.6)
-  delivery-cluster (0.2.19)
+  delivery-cluster (0.2.21)
     chef-server-12 (>= 0.0.0)
     chef-server-ingredient (>= 0.0.0)
     chef-splunk (>= 0.0.0)

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'Apache 2.0'
 description      'Deployment cookbook for standing up Delivery Clusters'
 long_description 'Installs Chef Delivery, a solution for continuously ' \
                  'delivering applications and infrastructure safely at speed'
-version          '0.2.20'
+version          '0.2.21'
 
 depends 'chef-server-12'
 depends 'chef-server-ingredient'

--- a/recipes/delivery.rb
+++ b/recipes/delivery.rb
@@ -58,6 +58,7 @@ else
 
   package 'delivery' do
     action :upgrade
+    notifies :run, 'execute[reconfigure delivery]'
   end
 end
 


### PR DESCRIPTION
As a user I expect to run a delivery-ctl reconfigure when delivery get upgraded using delivery-cluster, so I don't have to run it manually.

Fixing Issue https://github.com/opscode-cookbooks/delivery-cluster/issues/129