### PR TITLE
Add FQDN option in the supermarket config

### DIFF
--- a/libraries/helpers_supermarket.rb
+++ b/libraries/helpers_supermarket.rb
@@ -25,7 +25,7 @@ module DeliveryCluster
     #
     # Supermarket Module
     #
-    # This module provides helpers related to the Supermerket Component
+    # This module provides helpers related to the Supermarket Component
     module Supermarket
       module_function
 
@@ -68,6 +68,7 @@ module DeliveryCluster
         return {} unless supermarket_enabled?(node)
         {
           'supermarket-config' => {
+            'fqdn' => supermarket_server_fqdn(node),
             'chef_server_url' => "https://#{DeliveryCluster::Helpers::ChefServer.chef_server_fqdn(node)}",
             'chef_oauth2_app_id' => get_supermarket_attribute(node, 'uid'),
             'chef_oauth2_secret' => get_supermarket_attribute(node, 'secret'),

--- a/spec/unit/libraries/helpers_supermarket_spec.rb
+++ b/spec/unit/libraries/helpers_supermarket_spec.rb
@@ -114,6 +114,7 @@ describe DeliveryCluster::Helpers::Supermarket do
       it 'returns the supermarket server configuration' do
         expect(described_class.supermarket_config(node)).to eq(
           'supermarket-config' => {
+            'fqdn' => 'supermarket-server.chef.io',
             'chef_server_url' => 'https://chef-server.chef.io',
             'chef_oauth2_app_id' => '768fd17555298930830180eedc8ff6ca45736a8c392bbcbe866c804efb25262d',
             'chef_oauth2_secret' => '154b8a364e60deb3d83771df9159639362cd59a60661a63f9b126e794bd95daa',


### PR DESCRIPTION
- This adds the 'fqdn' attribute into the supermarket.json file which configures the supermarket service to run and allows you to run behind a custom dns entry